### PR TITLE
Allow deploy to new branch (or new server)

### DIFF
--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -2,7 +2,9 @@ namespace :nvm do
   task :validate do
     on release_roles(fetch(:nvm_roles)) do
       within release_path do
-        unless test 'node', '--version'
+        if test 'node', '--version'
+          puts "node #{fetch(:nvm_node)} is installed"
+        else
           puts "node #{fetch(:nvm_node)} not installed"
           exit 1
         end
@@ -38,8 +40,8 @@ namespace :nvm do
 end
 
 Capistrano::DSL.stages.each do |stage|
-  after stage, 'nvm:map_bins'
-  after stage, 'nvm:validate'
+  before 'deploy:updated', 'nvm:map_bins'
+  before 'deploy:updated', 'nvm:validate'
 end
 
 namespace :load do


### PR DESCRIPTION
It’s not possible to perform an nvm:validate unless the current .nvmrc is deployed.  

So we’ll wait to validate our node version until after we’ve deployed our source but before we do an npm:install.  This will allow us to do new branch deployment and new servers.