### PR TITLE
use `nvm_custom_path` in favor of `nvm_source_path`

### DIFF
--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -32,34 +32,27 @@ namespace :nvm do
     SSHKit.config.default_env.merge!({
       nvm_dir: fetch(:nvm_path)
     })
-    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:nvm_source_path)}/nvm-exec" } )
+    nvm_prefix = fetch(:nvm_prefix, -> { "#{fetch(:nvm_path)}/nvm-exec" } )
     fetch(:nvm_map_bins).each do |command|
       SSHKit.config.command_map.prefix[command.to_sym].unshift(nvm_prefix)
     end
   end
-end
 
-Capistrano::DSL.stages.each do |stage|
-  before 'deploy:updated', 'nvm:map_bins'
-  before 'deploy:updated', 'nvm:validate'
-end
-
-namespace :load do
-  task :defaults do
-
+  task :configure do
     set :nvm_path, -> {
-      nvm_path = fetch(:nvm_custom_path)
-      nvm_path ||= if fetch(:nvm_type, :user) == :system
+      system_or_user_path = if fetch(:nvm_type, :user) == :system
         "/usr/local/nvm"
       else
         "$HOME/.nvm"
       end
-    }
-
-    set :nvm_source_path, -> {
-       fetch(:nvm_source_path, fetch(:nvm_path))
+      fetch(:nvm_custom_path, system_or_user_path)
     }
     set :nvm_roles, fetch(:nvm_roles, :all)
     set :nvm_map_bins, %w{node npm}
   end
+
 end
+
+before 'deploy:starting', 'nvm:configure'
+before 'deploy:updated',  'nvm:map_bins'
+before 'deploy:updated',  'nvm:validate'

--- a/lib/capistrano/tasks/nvm.cap
+++ b/lib/capistrano/tasks/nvm.cap
@@ -41,10 +41,10 @@ namespace :nvm do
   task :configure do
     set :nvm_path, -> {
       system_or_user_path = if fetch(:nvm_type, :user) == :system
-        "/usr/local/nvm"
-      else
-        "$HOME/.nvm"
-      end
+                             "/usr/local/nvm"
+                            else
+                              "$HOME/.nvm"
+                            end
       fetch(:nvm_custom_path, system_or_user_path)
     }
     set :nvm_roles, fetch(:nvm_roles, :all)


### PR DESCRIPTION
 In the end we only care about the path where `nvm-exec` exists.  This pull request does the following:

- remove `nvm_source_path` configuration option

- use a 'before' hook to configure the nvm settings.  the prior use of a `load:defaults` task actually attempted to initialize the nvm configuration _before_ we even set our preferences in `deploy.rb`

- if you are not using the "standard" user or system path, the user can specify an `nvm_custom_path`